### PR TITLE
Add option in scripts to generate colored svg icons

### DIFF
--- a/tools/generatepng.sh
+++ b/tools/generatepng.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Usage: generatepng.sh type outputformat
+# type can be 'all', default is 'all'
+# outputformat can be 'png' or 'svg', default is 'png'
+
 pushd . > /dev/null
 cd `dirname $BASH_SOURCE` > /dev/null
 BASEFOLDER=`pwd`;
@@ -12,17 +16,25 @@ FORGROUND_COLOURS=( '#0092DA'       '#734A08' '#666666' '#39AC39'   '#734A08' '#
 SIZES=(64 48 32 24 20 16 12)
 
 SVGFOLDER=${BASEFOLDER}/svg/
-OUTPUTFOLDER=${BASEFOLDER}/png/
+OUTPUTFOLDER=${BASEFOLDER}/out/
 
 if [ ! -d "${OUTPUTFOLDER}" ]; then
   mkdir ${OUTPUTFOLDER}
 fi
 
+if [ "$2" == "" ]; then
+	OUTPUTFORMAT="png"
+else
+	OUTPUTFORMAT="$2"
+fi
+
+if [ "$OUTPUTFORMAT" == "svg" ]; then
+        SIZES=(12)
+fi
+
 for (( i = 0 ; i < ${#TYPES[@]} ; i++ )) do
 
-  if  [ "$1" == "" -o "$1" == "${TYPES[i]}" ]; then
-
-    echo "On: ${TYPES[i]}"
+  if  [ "$1" == "" -o "$1" == "${TYPES[i]}" -o "$1" == "all" ]; then
 
     for FILE in $SVGFOLDER${TYPES[i]}/*.svg; do
 
@@ -30,9 +42,11 @@ for (( i = 0 ; i < ${#TYPES[@]} ; i++ )) do
       BASENAME=${OUTPUTFOLDER}${TYPES[i]}_${BASENAME%.*}
 
       for (( j = 0 ; j < ${#SIZES[@]} ; j++ )) do
-        ${BASEFOLDER}/tools/recolourtopng.sh ${FILE} 'none' 'none' ${FORGROUND_COLOURS[i]} ${SIZES[j]} ${BASENAME}.p.${SIZES[j]}
-        ${BASEFOLDER}/tools/recolourtopng.sh ${FILE} ${FORGROUND_COLOURS[i]} ${FORGROUND_COLOURS[i]} '#ffffff' ${SIZES[j]} ${BASENAME}.n.${SIZES[j]}
-        convert ${BASENAME}.p.${SIZES[j]}.png \( +clone -background "#ffffff" -shadow 8000x2-0+0 \) +swap -background none -layers merge +repage -trim ${BASENAME}.glow.${SIZES[j]}.png
+        ${BASEFOLDER}/tools/recolourtopng.sh ${FILE} 'none' 'none' ${FORGROUND_COLOURS[i]} ${SIZES[j]} ${BASENAME}.p.${SIZES[j]} $OUTPUTFORMAT
+        ${BASEFOLDER}/tools/recolourtopng.sh ${FILE} ${FORGROUND_COLOURS[i]} ${FORGROUND_COLOURS[i]} '#ffffff' ${SIZES[j]} ${BASENAME}.n.${SIZES[j]} $OUTPUTFORMAT
+        if [ "$OUTPUTFORMAT" == "png" ]; then
+          convert ${BASENAME}.p.${SIZES[j]}.png \( +clone -background "#ffffff" -shadow 8000x2-0+0 \) +swap -background none -layers merge +repage -trim ${BASENAME}.glow.${SIZES[j]}.png
+        fi
       done
 
     done

--- a/tools/recolourtopng.sh
+++ b/tools/recolourtopng.sh
@@ -6,6 +6,7 @@
 # $4 forground
 # $5 png size
 # $6 output filename
+# $7 output format ('svg' or 'png')
 
 pushd . > /dev/null
 cd `dirname $BASH_SOURCE` > /dev/null
@@ -13,4 +14,10 @@ BASEFOLDER=`pwd`;
 popd  > /dev/null
 BASEFOLDER=`dirname $BASEFOLDER`
 
-${BASEFOLDER}/tools/recolour.sh $1 $2 $3 $4 | rsvg -f png -w ${5} -h ${5} /dev/stdin ${6}.png
+if [ "${7}" == "png" ]; then
+  ${BASEFOLDER}/tools/recolour.sh $1 $2 $3 $4 | rsvg -f png -w ${5} -h ${5} /dev/stdin ${6}.png
+elif [ "${7}" == "svg" ]; then
+  ${BASEFOLDER}/tools/recolour.sh $1 $2 $3 $4 > ${6}.svg
+else
+  echo "Unknown output format"
+fi


### PR DESCRIPTION
This adds an option to generatepng.sh for the generation of icons in svg format.

Related to the discussion [here](https://github.com/gravitystorm/openstreetmap-carto/pull/1041#issuecomment-59262646).
